### PR TITLE
teach estatsd to support a custom name intead of just node()

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,9 +23,6 @@ USAGE
 Add this app to your rebar deps, and make sure it's started somehow
 eg: application:start(estatsd).
 
-You can configure custom graphite host/port and flush interval using 
-application environment vars. See estatsd_sup for details.
-
 The following calls to estatsd are all gen_server:cast, ie non-blocking.
 
 Gauges
@@ -53,7 +50,18 @@ Or for your convenience:
     do_sometask(), 
     estatsd:timing(sometast, Start).        %% uses now() and now_diff for you
 
+Configuration
+-------------
 
+You can configure custom graphite host/port and flush interval using
+application environment vars, track Erlang internal metrics, including
+setting a custom prefix or defaulting to the Erlang node name:
+
+- `flush_interval` -- ms interval between flushing of stats to graphit
+- `graphite_host`  -- graphite server host
+- `graphite_port`  -- graphite server port
+- `vm_metrics`     -- true/false flag to enable sending VM metrics on flush
+- `vm_name`        -- use the provided atom instead of node()
 
 NOTES
 =====

--- a/src/estatsd_sup.erl
+++ b/src/estatsd_sup.erl
@@ -12,6 +12,7 @@
 -define(GRAPHITE_HOST,  appvar(graphite_host,  "127.0.0.1")).
 -define(GRAPHITE_PORT,  appvar(graphite_port,  2003)).
 -define(VM_METRICS,     appvar(vm_metrics,  true)).
+-define(VM_NAME,        appvar(vm_name,  node())).
 
 %% ===================================================================
 %% API functions
@@ -19,28 +20,28 @@
 
 
 start_link() ->
-    start_link( ?FLUSH_INTERVAL, ?GRAPHITE_HOST, ?GRAPHITE_PORT, ?VM_METRICS).
+    start_link( ?FLUSH_INTERVAL, ?GRAPHITE_HOST, ?GRAPHITE_PORT, ?VM_METRICS, ?VM_NAME).
 
 start_link(FlushIntervalMs) ->
-    start_link( FlushIntervalMs, ?GRAPHITE_HOST, ?GRAPHITE_PORT, ?VM_METRICS).
+    start_link( FlushIntervalMs, ?GRAPHITE_HOST, ?GRAPHITE_PORT, ?VM_METRICS, ?VM_NAME).
 
 start_link(FlushIntervalMs, GraphiteHost, GraphitePort) ->
-    start_link( FlushIntervalMs, GraphiteHost, GraphitePort, ?VM_METRICS).
+    start_link( FlushIntervalMs, GraphiteHost, GraphitePort, ?VM_METRICS, ?VM_NAME).
 
-start_link(FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics) ->
+start_link(FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics, VmName) ->
     supervisor:start_link({local, ?MODULE}, 
                           ?MODULE, 
-                          [FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics]).
+                          [FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics, VmName]).
 
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
-init([FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics]) ->
+init([FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics, VmName]) ->
     Children = [
         {estatsd_server, 
          {estatsd_server, start_link, 
-             [FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics]},
+             [FlushIntervalMs, GraphiteHost, GraphitePort, VmMetrics, VmName]},
          permanent, 5000, worker, [estatsd_server]}
     ],
     {ok, { {one_for_one, 10000, 10}, Children} }.


### PR DESCRIPTION
estatsd gets the node name from node() directly. If running epmd and connecting the erlang node to the network isn't possible, this means the default atom nonode@nohost is used.

This patch enables estatsd to use a new application environment VmName, which if present, is used in NodeKey instead. This allows nice, and unique, metric names in graphite without needing epmd and connecting the node to the erlang network.
